### PR TITLE
Quilt README: Replace image with text

### DIFF
--- a/docs/quilt/README.md
+++ b/docs/quilt/README.md
@@ -12,7 +12,12 @@ This dataset can be accessed on quilt [here](https://open.quiltdata.com/b/allenc
 
 The `emt_timelapse_dataset` directory is organized in the following structure.
 
-<img src="https://github.com/AllenCell/EMT_data_analysis/blob/bioRxiv-v1/docs/quilt/dataset_structure.svg" width="500px" />
+```
+emt_timelapse_dataset
+├── data
+├── manifests
+└── supplemental_files
+```
 
 ## data
 


### PR DESCRIPTION
My attempt to host the directory structure figure on github didn't work, because quilt won't load images from external websites. This means that the only way to get the directory structure figure displayed on quilt is to add it to the quilt bucket. There was some concern about the extra file creating confusion, so this PR addresses the issue by using a text diagram instead of an image.

View the proposed [README here](https://github.com/AllenCell/EMT_data_analysis/blob/2a4888870cb24adf1c8c68a295d92ada1c5b7964/docs/quilt/README.md)

What do you all think?