### PR TITLE
Additional plot/analysis for comparing migration times

### DIFF
--- a/EMT_data_analysis/analysis_scripts/Analysis_tools.py
+++ b/EMT_data_analysis/analysis_scripts/Analysis_tools.py
@@ -1,5 +1,6 @@
 import warnings
 import numpy as np
+import math
 import pandas as pd
 import seaborn as sns
 import plotly.express as px
@@ -47,7 +48,7 @@ def run_all_analyses():
     analyze_crispr_knockdown_experiments(df, FIGS_DIR, OUT_TYPE)
     plot_inside_outside_migration_timing(df, FIGS_DIR, OUT_TYPE)
     plot_mmp_inhibitor_migration(df, FIGS_DIR, OUT_TYPE)
-    plot_bmp_inhibitor_migration(df_bmp, FIGS_DIR)
+    plot_bmp_inhibitor_migration(df_bmp, FIGS_DIR, OUT_TYPE)
     plot_zo1_heatmaps(df, FIGS_DIR, OUT_TYPE)
     # plot_immunolabeling_heatmap(FIGS_DIR, OUT_TYPE)  # need data added for this
 
@@ -144,6 +145,7 @@ def plot_area_at_glass_all_data(df, figs_dir, out_type):
     plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left') 
     plt.savefig(rf'{figs_dir}/Area_at_the_glass_over_time_MIP_n{n_a}.{out_type}', transparent=True, dpi=600)
 
+    Path(rf'{figs_dir}/Individual_Examples').mkdir(exist_ok=True, parents=True)
     plot_tools.plot_examples(
         df_int = df_f,
         id_plf = const.EXAMPLE_PLF,
@@ -350,7 +352,6 @@ def plot_mean_intensity_by_gene(df, figs_dir, out_type):
         plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left') 
         plt.savefig(fr'{figs_dir}/Mean_intensity_plot_{g}_n{n}_mean_line.{out_type}', dpi=600, transparent=True) 
 
-    Path(rf'{figs_dir}/Individual_Examples').mkdir(exist_ok=True, parents=True)
     # Time of max EOMES expression (h) examples
     plot_tools.plot_examples(
         df_int = df_int,
@@ -910,6 +911,74 @@ def plot_zo1_heatmaps(df, figs_dir, out_type):
     plot_tools.Intensity_over_z(df_zo_examples, figs_dir=figs_dir+'/ZO1', out_type=out_type)
 
 
+def _get_linear_relationship_from_covariance(x, y):
+    """
+    Use eigenvectors of covariance matrix to determine linear mapping between migration times from two methods.
+    This method constructs the covariance matrix for the two sets of migration timing measurements and determines
+    its eigenvectors and eigenvalues. The eigenvector with highest eigenvalue lies along the direction of
+    greatest variation in the data. A line colinear with this vector is used to define a linear
+    mapping between the two migration times. The eigenvalue associated with the second eigenvector,
+    perpendicular to the linear mapping, defines the standard deviatin away from this line.
+
+    Parameters
+    ----------
+    x : pd.Series
+        Migration times measured by the first method
+    y : pd.Series
+        Migration times measured by the second method
+
+    Returns
+    -------
+    slope, intercept : float
+        Slope and intercept of the linear mapping between the two sets of migration times
+    std: float
+        Standard deviation of the migration times from the linear mapping
+    """
+
+    # Format live and fixed features as needed for analysis and calculated the mean of each
+    mean_x = np.mean(x)
+    mean_y = np.mean(y)
+    center = (float(mean_x), float(mean_y))
+
+    # Get covaraince matrix of live and fixed data then calculate its eigenvectors and eigenvalues
+    data = [[x_i, y_i] for x_i, y_i in zip(x, y)]
+    covariance_matrix = np.cov(data, rowvar=False)
+    eigenvalues, eigenvectors = np.linalg.eig(covariance_matrix)
+
+    # Get indices that would sort the eigenvalues in ascending order
+    sorted_indices = eigenvalues.argsort()[::-1]
+
+    # Sort eigenvalues and eigenvectors
+    eigenvalues = eigenvalues[sorted_indices]
+    eigenvectors = eigenvectors[:, sorted_indices]
+
+    # Get slope and intercept of line defined by first eigenvector
+    slope = eigenvectors[1, 0] / eigenvectors[0, 0]
+    intercept = mean_y - slope * mean_x
+    # Get standard deviation perpendicular to the line defined by the first eigenvector
+    std = np.sqrt(eigenvalues[1])
+
+    return slope, intercept, std
+
+def _get_perpendicular_distance(x_i, y_i, A, B, C):
+  """
+  Calculate the perpendicular distance from a point (x_i, y_i) to a line Ax+By+C=0.
+
+  Args:
+    x_i: x-coordinate of the point
+    y_i: y-coordinate of the point
+    A: coefficient of x in the line equation Ax+By+C=0
+    B: coefficient of y in the line equation Ax+By+C=0
+    C: constant term in the line equation Ax+By+C=0
+
+  Returns:
+    The perpendicular distance from the point to the line.
+  """
+  numerator = abs(A * x_i + B * y_i + C)
+  denominator = math.sqrt(A**2 + B**2)
+  distance = numerator / denominator
+  return distance
+
 def plot_inside_outside_migration_timing(df, figs_dir, out_type):
     """
     Analyzes the inside-outside classification of nuclei in the basement membrane and plots the fraction of nuclei outside the lumen over time.
@@ -1061,6 +1130,34 @@ def plot_inside_outside_migration_timing(df, figs_dir, out_type):
     print(f"Slope (Coefficient for migration timing): {slope_coeff:.3g}")
     print(f"P-value for the slope: {slope_p_value:.3g}")
 
+    # Using the covariance matrix to define a linear mapping between migration times from two methods
+    X = dfio_scatter['Migration Time (h)']
+    Y = dfio_scatter['Migration Time InOut (h)']
+    slope, intercept, std = _get_linear_relationship_from_covariance(X, Y)
+    print("\n--- Defining a linear relatioship from eigenvectors of covariance matrix ---")
+    print(f"Slope: {slope:.3g}")
+    print(f"Intercept: {intercept:.3g}")
+    print(f"Standard Deviation: {std:.3g}")
+
+    # Plotting migration time estimated from inside and outside classification of nuclei w.r.t basement memebrane vs migration time estimated from area at the glass (Fig. 5I)
+    fig_scatter, ax = plt.subplots(1,1, figsize=(10,10))
+    fig_scatter = sns.scatterplot(dfio_scatter, x='Migration Time (h)', y='Migration Time InOut (h)', hue='Condition order for plots', palette=const.COLOR_MAP, s=100, alpha=0.7, linewidth=2, edgecolor='coral', legend=False)
+    fig_scatter = sns.lineplot(x=[16,36], y=[slope*16+intercept,slope*36+intercept], color='black', linestyle='-', label='Linear mapping', ax=ax)
+    # draw unity line
+    fig_scatter = sns.lineplot(x=[16, 36], y=[16, 36], color='gray', linestyle='--', label='Unity line', ax=ax)
+    plt.xlim(16,36)
+    plt.ylim(16,36)
+
+    plt.xlabel('Migration Time from area at glass (h)', fontsize=16)
+    plt.ylabel('Migration Time fraction of nuclei outside basement membrane (h)', fontsize=16)
+    plt.rcParams.update({'font.size':16})
+    plt.savefig(fr'{figs_dir}/Inside-Outside/Scatter_plot_between_computer_migration_area_on_glass_vs_inside_outside_with_linearmap.{out_type}', dpi=600, transparent=True)
+
+    # get minimum x or y value
+    sample_val = min(X.min(), Y.min())
+    dist = _get_perpendicular_distance(sample_val, sample_val, slope, -1, intercept)
+    print(f"Distance from linear mapping at ({sample_val},{sample_val}): {dist:.3g}")
+    print(f"Fraction of a standard deviation away from the linear mapping at {sample_val},{sample_val}): {dist/std:.3g}")
 
 
 def plot_bmp_inhibitor_migration(df_BMP, figs_dir: str, out_type):

--- a/EMT_data_analysis/analysis_scripts/Analysis_tools.py
+++ b/EMT_data_analysis/analysis_scripts/Analysis_tools.py
@@ -18,8 +18,6 @@ plt.rcParams["font.family"] = "Arial"
 
 warnings.filterwarnings("ignore")
 
-# TODO  I assume this will live somewhere else eventually but placed this here for now
-# to test that the functions all run
 def run_all_analyses():
     """
     Run all analysis functions
@@ -28,7 +26,8 @@ def run_all_analyses():
     DATA_PATH = '/allen/aics/users/filip.sluzewski/Public_Repos/emt-data-analysis/resubmission_scripts/Complete EMT Data - Segmentation Data.csv'
     BMP_DATA_PATH ='/allen/aics/emt/qc_and_scoring/Dataset making/July/July 24/Leica files with path to bad omezarr July 24 2025.csv'
     BMP_MIG_DATA_PATH = '/allen/aics/users/filip.sluzewski/Public_Repos/emt-data-analysis/resubmission_scripts/GE00006359_FINAL_BMP_Inhibitor_Scores_update_1.csv'
-    FIGS_DIR = '/allen/aics/emt/data_analysis_plots/Colony_Metrics/full_dataset_figures/'
+    # FIGS_DIR = '/allen/aics/emt/data_analysis_plots/Colony_Metrics/full_dataset_figures/'
+    FIGS_DIR = "figures/"
     OUT_TYPE = 'svg'
 
     df, df_bmp = load_and_prep_datasets(
@@ -37,6 +36,7 @@ def run_all_analyses():
         bmp_mig_data_path = BMP_MIG_DATA_PATH,
         figs_dir=FIGS_DIR)
     
+    """
     plot_area_at_glass_all_data(df, FIGS_DIR, OUT_TYPE)
     plot_area_at_glass_h2b(df, FIGS_DIR, OUT_TYPE)
     plot_migration_timing_all_data(df, FIGS_DIR, OUT_TYPE)
@@ -45,7 +45,7 @@ def run_all_analyses():
     plot_mean_intensity_by_gene(df, FIGS_DIR, OUT_TYPE)
     plot_gene_expression_experiments(df, FIGS_DIR, OUT_TYPE)
     plot_collagenase_analysis(df, FIGS_DIR, OUT_TYPE)
-    analyze_crispr_knockdown_experiments(df, FIGS_DIR, OUT_TYPE)
+    analyze_crispr_knockdown_experiments(df, FIGS_DIR, OUT_TYPE) """
     plot_inside_outside_migration_timing(df, FIGS_DIR, OUT_TYPE)
     plot_mmp_inhibitor_migration(df, FIGS_DIR, OUT_TYPE)
     plot_bmp_inhibitor_migration(df_bmp, FIGS_DIR, OUT_TYPE)
@@ -1140,24 +1140,21 @@ def plot_inside_outside_migration_timing(df, figs_dir, out_type):
     print(f"Standard Deviation: {std:.3g}")
 
     # Plotting migration time estimated from inside and outside classification of nuclei w.r.t basement memebrane vs migration time estimated from area at the glass (Fig. 5I)
+    plt.clf()
     fig_scatter, ax = plt.subplots(1,1, figsize=(10,10))
     fig_scatter = sns.scatterplot(dfio_scatter, x='Migration Time (h)', y='Migration Time InOut (h)', hue='Condition order for plots', palette=const.COLOR_MAP, s=100, alpha=0.7, linewidth=2, edgecolor='coral', legend=False)
-    fig_scatter = sns.lineplot(x=[16,36], y=[slope*16+intercept,slope*36+intercept], color='black', linestyle='-', label='Linear mapping', ax=ax)
+    legend_linear_mapping = f"{slope:.3g}x+{intercept:.3g}, $\sigma$={std:.3g}"
+    fig_scatter = sns.lineplot(x=[16,36], y=[slope*16+intercept,slope*36+intercept], color='black', linestyle='-', label=legend_linear_mapping, ax=ax)
     # draw unity line
     fig_scatter = sns.lineplot(x=[16, 36], y=[16, 36], color='gray', linestyle='--', label='Unity line', ax=ax)
     plt.xlim(16,36)
     plt.ylim(16,36)
+    plt.legend()
 
     plt.xlabel('Migration Time from area at glass (h)', fontsize=16)
     plt.ylabel('Migration Time fraction of nuclei outside basement membrane (h)', fontsize=16)
     plt.rcParams.update({'font.size':16})
     plt.savefig(fr'{figs_dir}/Inside-Outside/Scatter_plot_between_computer_migration_area_on_glass_vs_inside_outside_with_linearmap.{out_type}', dpi=600, transparent=True)
-
-    # get minimum x or y value
-    sample_val = min(X.min(), Y.min())
-    dist = _get_perpendicular_distance(sample_val, sample_val, slope, -1, intercept)
-    print(f"Distance from linear mapping at ({sample_val},{sample_val}): {dist:.3g}")
-    print(f"Fraction of a standard deviation away from the linear mapping at {sample_val},{sample_val}): {dist/std:.3g}")
 
 
 def plot_bmp_inhibitor_migration(df_BMP, figs_dir: str, out_type):
@@ -1335,7 +1332,7 @@ def plot_immunolabeling_heatmap(figs_dir: str, output_type: str) -> None:
     # Create heatmap of the final intensities for each time for each Label
     _create_heatmap(df_sort, title="immuno_heatmap", figs_dir=figs_dir, output_type=output_type)
 
-# TODO  I assume this will live somewhere else eventually but placed this here for now
-# to test that the functions all run
-run_all_analyses()
+
+if __name__ == '__main__':
+    run_all_analyses()
 

--- a/EMT_data_analysis/analysis_scripts/Analysis_tools.py
+++ b/EMT_data_analysis/analysis_scripts/Analysis_tools.py
@@ -26,8 +26,7 @@ def run_all_analyses():
     DATA_PATH = '/allen/aics/users/filip.sluzewski/Public_Repos/emt-data-analysis/resubmission_scripts/Complete EMT Data - Segmentation Data.csv'
     BMP_DATA_PATH ='/allen/aics/emt/qc_and_scoring/Dataset making/July/July 24/Leica files with path to bad omezarr July 24 2025.csv'
     BMP_MIG_DATA_PATH = '/allen/aics/users/filip.sluzewski/Public_Repos/emt-data-analysis/resubmission_scripts/GE00006359_FINAL_BMP_Inhibitor_Scores_update_1.csv'
-    # FIGS_DIR = '/allen/aics/emt/data_analysis_plots/Colony_Metrics/full_dataset_figures/'
-    FIGS_DIR = "figures/"
+    FIGS_DIR = '/allen/aics/emt/data_analysis_plots/Colony_Metrics/full_dataset_figures/'
     OUT_TYPE = 'svg'
 
     df, df_bmp = load_and_prep_datasets(
@@ -36,7 +35,6 @@ def run_all_analyses():
         bmp_mig_data_path = BMP_MIG_DATA_PATH,
         figs_dir=FIGS_DIR)
     
-    """
     plot_area_at_glass_all_data(df, FIGS_DIR, OUT_TYPE)
     plot_area_at_glass_h2b(df, FIGS_DIR, OUT_TYPE)
     plot_migration_timing_all_data(df, FIGS_DIR, OUT_TYPE)
@@ -45,7 +43,7 @@ def run_all_analyses():
     plot_mean_intensity_by_gene(df, FIGS_DIR, OUT_TYPE)
     plot_gene_expression_experiments(df, FIGS_DIR, OUT_TYPE)
     plot_collagenase_analysis(df, FIGS_DIR, OUT_TYPE)
-    analyze_crispr_knockdown_experiments(df, FIGS_DIR, OUT_TYPE) """
+    analyze_crispr_knockdown_experiments(df, FIGS_DIR, OUT_TYPE)
     plot_inside_outside_migration_timing(df, FIGS_DIR, OUT_TYPE)
     plot_mmp_inhibitor_migration(df, FIGS_DIR, OUT_TYPE)
     plot_bmp_inhibitor_migration(df_bmp, FIGS_DIR, OUT_TYPE)

--- a/EMT_data_analysis/analysis_scripts/Analysis_tools.py
+++ b/EMT_data_analysis/analysis_scripts/Analysis_tools.py
@@ -958,24 +958,6 @@ def _get_linear_relationship_from_covariance(x, y):
 
     return slope, intercept, std
 
-def _get_perpendicular_distance(x_i, y_i, A, B, C):
-  """
-  Calculate the perpendicular distance from a point (x_i, y_i) to a line Ax+By+C=0.
-
-  Args:
-    x_i: x-coordinate of the point
-    y_i: y-coordinate of the point
-    A: coefficient of x in the line equation Ax+By+C=0
-    B: coefficient of y in the line equation Ax+By+C=0
-    C: constant term in the line equation Ax+By+C=0
-
-  Returns:
-    The perpendicular distance from the point to the line.
-  """
-  numerator = abs(A * x_i + B * y_i + C)
-  denominator = math.sqrt(A**2 + B**2)
-  distance = numerator / denominator
-  return distance
 
 def plot_inside_outside_migration_timing(df, figs_dir, out_type):
     """


### PR DESCRIPTION
Major:
Adds additional version of scatter plot comparing migration timing measurements, using eigenvectors and eigenvalues of covariance matrix to find linear mapping and standard deviation away from this line

Minor:
Wrap call of function to run all analysis workflows in if __main__ statement

<img width="6000" height="6000" alt="Scatter_plot_between_computer_migration_area_on_glass_vs_inside_outside_with_linearmap" src="https://github.com/user-attachments/assets/09b55654-b90d-41e8-aaaa-70b78e417d91" />
